### PR TITLE
Mask passwords while error logging

### DIFF
--- a/src/com/tw/go/plugin/GitHelper.java
+++ b/src/com/tw/go/plugin/GitHelper.java
@@ -47,11 +47,7 @@ public abstract class GitHelper {
     }
 
     public boolean isSameRepository() {
-        try {
-            return workingRepositoryUrl().equals(gitConfig.getEffectiveUrl());
-        } catch (Exception e) {
-            return false;
-        }
+        return workingRepositoryUrl().equals(gitConfig.getEffectiveUrl());
     }
 
     private void setupWorkingDir() {

--- a/src/com/tw/go/plugin/GitHelper.java
+++ b/src/com/tw/go/plugin/GitHelper.java
@@ -47,7 +47,11 @@ public abstract class GitHelper {
     }
 
     public boolean isSameRepository() {
-        return workingRepositoryUrl().equals(gitConfig.getEffectiveUrl());
+        try {
+            return workingRepositoryUrl().equals(gitConfig.getEffectiveUrl());
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private void setupWorkingDir() {

--- a/src/com/tw/go/plugin/cmd/Console.java
+++ b/src/com/tw/go/plugin/cmd/Console.java
@@ -13,8 +13,12 @@ public class Console {
         gitCmd.addArguments(args);
         return gitCmd;
     }
-
+    
     public static ConsoleResult runOrBomb(CommandLine commandLine, File workingDir, ProcessOutputStreamConsumer stdOut, ProcessOutputStreamConsumer stdErr) {
+        return runOrBomb(commandLine, workingDir, stdOut, stdErr, commandLine.toString());
+    }
+
+    public static ConsoleResult runOrBomb(CommandLine commandLine, File workingDir, ProcessOutputStreamConsumer stdOut, ProcessOutputStreamConsumer stdErr, String prettyMessage) {
         Executor executor = new DefaultExecutor();
         executor.setStreamHandler(new PumpStreamHandler(stdOut, stdErr));
         if (workingDir != null) {
@@ -25,16 +29,16 @@ public class Console {
             int exitCode = executor.execute(commandLine);
 
             if (exitCode != 0) {
-                throw new RuntimeException(getMessage("Error", commandLine, workingDir));
+                throw new RuntimeException(getMessage("Error", prettyMessage, workingDir));
             }
 
             return new ConsoleResult(exitCode, stdOut.output(), stdErr.output());
         } catch (Exception e) {
-            throw new RuntimeException(getMessage("Exception", commandLine, workingDir), e);
+            throw new RuntimeException(getMessage("Exception", prettyMessage, workingDir), e);
         }
     }
 
-    private static String getMessage(String type, CommandLine commandLine, File workingDir) {
-        return String.format("%s Occurred: %s - %s", type, commandLine.toString(), workingDir);
+    private static String getMessage(String type, String prettyMessage, File workingDir) {
+        return String.format("%s Occurred: %s - %s", type, prettyMessage, workingDir);
     }
 }

--- a/src/com/tw/go/plugin/model/GitConfig.java
+++ b/src/com/tw/go/plugin/model/GitConfig.java
@@ -42,10 +42,25 @@ public class GitConfig {
         }
         return getUrl();
     }
+    
+    public String getEffectiveMaskedUrl() {
+        if (isRemoteUrl() && hasCredentials()) {
+            return getUrlWithMaskedCredentials();
+        }
+        return getUrl();
+    }
+    
+    private String getUrlWithCredentials(String user, String pass) {
+        String[] parts = url.split("://");
+        return String.format("%s://%s:%s@%s", parts[0], user, pass, parts[1]);
+    }
 
     public String getUrlWithCredentials() {
-        String[] parts = url.split("://");
-        return String.format("%s://%s:%s@%s", parts[0], username, password, parts[1]);
+        return getUrlWithCredentials(username, password);
+    }
+    
+    public String getUrlWithMaskedCredentials() {
+        return getUrlWithCredentials(username, StringUtil.repeat("*", password.length()));
     }
 
     public String getUrl() {

--- a/src/com/tw/go/plugin/util/StringUtil.java
+++ b/src/com/tw/go/plugin/util/StringUtil.java
@@ -4,4 +4,12 @@ public class StringUtil {
     public static boolean isEmpty(String str) {
         return str == null || str.trim().isEmpty();
     }
+    
+    public static String repeat(String str, int count) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            result.append(str);
+        }
+        return result.toString();
+    }
 }

--- a/test/com/tw/go/plugin/model/GitConfigTest.java
+++ b/test/com/tw/go/plugin/model/GitConfigTest.java
@@ -14,6 +14,15 @@ public class GitConfigTest {
         assertThat(new GitConfig("http://github.com/gocd/gocd", "username", "password", null).getEffectiveUrl(), is("http://username:password@github.com/gocd/gocd"));
         assertThat(new GitConfig("https://github.com/gocd/gocd", "username", "password", null).getEffectiveUrl(), is("https://username:password@github.com/gocd/gocd"));
     }
+    
+    @Test
+    public void shouldGetEffectiveMaskedUrl() throws Exception {
+        assertThat(new GitConfig("/tmp/git-repo", null, null, null).getEffectiveMaskedUrl(), is("/tmp/git-repo"));
+        assertThat(new GitConfig("/tmp/git-repo", "username", "password", null).getEffectiveMaskedUrl(), is("/tmp/git-repo"));
+        assertThat(new GitConfig("http://github.com/gocd/gocd", null, null, null).getEffectiveMaskedUrl(), is("http://github.com/gocd/gocd"));
+        assertThat(new GitConfig("http://github.com/gocd/gocd", "username", "password", null).getEffectiveMaskedUrl(), is("http://username:********@github.com/gocd/gocd"));
+        assertThat(new GitConfig("https://github.com/gocd/gocd", "username", "password", null).getEffectiveMaskedUrl(), is("https://username:********@github.com/gocd/gocd"));
+    }
 
     @Test
     public void shouldGetEffectiveBranch() throws Exception {


### PR DESCRIPTION
It's really awkward when git passwords are shown in logs and on UI while checking connection and checking out the project.
Let's follow common practice and mask them where needed.
