### PR TITLE
Do not fail clone after repository checks fail

### DIFF
--- a/src/com/tw/go/plugin/GitHelper.java
+++ b/src/com/tw/go/plugin/GitHelper.java
@@ -47,7 +47,11 @@ public abstract class GitHelper {
     }
 
     public boolean isSameRepository() {
-        return workingRepositoryUrl().equals(gitConfig.getEffectiveUrl());
+        try {
+            return workingRepositoryUrl().equals(gitConfig.getEffectiveUrl());
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private void setupWorkingDir() {


### PR DESCRIPTION
Af some point I started to get error below while check out project
And here fix for it

```
2015-08-27 18:19:51,220  WARN [loopThread] GitHubPRBuildPlugin:67 - checkout: 
java.lang.RuntimeException: Exception Occurred: [git, config, remote.origin.url] - D:\Sys\Go_Agent\pipelines\CI-Apps\apps
    at com.tw.go.plugin.cmd.Console.runOrBomb(Console.java:33)
    at com.tw.go.plugin.git.GitCmdHelper.runAndGetOutput(GitCmdHelper.java:397)
    at com.tw.go.plugin.git.GitCmdHelper.runAndGetOutput(GitCmdHelper.java:393)
    at com.tw.go.plugin.git.GitCmdHelper.runAndGetOutput(GitCmdHelper.java:389)
    at com.tw.go.plugin.git.GitCmdHelper.workingRepositoryUrl(GitCmdHelper.java:67)
    at com.tw.go.plugin.GitHelper.isSameRepository(GitHelper.java:50)
    at com.tw.go.plugin.GitHelper.cloneOrFetch(GitHelper.java:36)
    at in.ashwanthkumar.gocd.github.GitHubPRBuildPlugin.handleCheckout(GitHubPRBuildPlugin.java:256)
    at in.ashwanthkumar.gocd.github.GitHubPRBuildPlugin.handle(GitHubPRBuildPlugin.java:90)
```
