### PR TITLE
Added extra checks to confirm there are submodules before the cleanup walk.

### DIFF
--- a/src/com/tw/go/plugin/jgit/JGitHelper.java
+++ b/src/com/tw/go/plugin/jgit/JGitHelper.java
@@ -318,9 +318,11 @@ public class JGitHelper extends GitHelper {
             Git git = new Git(repository);
 
             walk = SubmoduleWalk.forIndex(repository);
-            while (walk.next()) {
-                cleanSubmoduleOfAllUnversionedFiles(walk);
-            }
+	    if (walk != null) {
+            	while (walk.next()) {
+                	cleanSubmoduleOfAllUnversionedFiles(walk);
+            	}
+	    }
 
             CleanCommand clean = git.clean().setCleanDirectories(true);
             clean.call();
@@ -340,8 +342,10 @@ public class JGitHelper extends GitHelper {
         Repository submoduleRepository = null;
         try {
             submoduleRepository = walk.getRepository();
-            CleanCommand clean = Git.wrap(submoduleRepository).clean().setCleanDirectories(true);
-            clean.call();
+	    if (submoduleRepository != null) {
+            	CleanCommand clean = Git.wrap(submoduleRepository).clean().setCleanDirectories(true);
+            	clean.call();
+	    }
         } catch (Exception e) {
             throw new RuntimeException("sub-module clean failed", e);
         } finally {


### PR DESCRIPTION
Ran into an issue where cleanup was walking submodules despite the repo not containing any submodules. This resulted in an issue with the 'gocd-build-github-pull-requests' plugin which depends on this repo. This plugin threw a "clean failed" exception when attempting to perform cleanup and would prevent execution of the pipeline. I resolved the issue by ensuring that the generator and submodule repo is not null before proceeding with cleanup of submodules.
