### PR TITLE
Fix path problems with macosx, no need to have CommandLine handle quotes, checked linux and windows as regression.

### DIFF
--- a/src/com/tw/go/plugin/cmd/Console.java
+++ b/src/com/tw/go/plugin/cmd/Console.java
@@ -10,7 +10,7 @@ import java.io.File;
 public class Console {
     public static CommandLine createCommand(String... args) {
         CommandLine gitCmd = new CommandLine("git");
-        gitCmd.addArguments(args);
+        gitCmd.addArguments(args, false);
         return gitCmd;
     }
 


### PR DESCRIPTION
Recent updates to the 'gocd-build-github-pull-requests', made this issue crop up. Paths on macosx are quoted twice, causing issues with cloning repos to directories with spaces in there path (like the default gocd agent path for mac). This issue was not present in linux or windows since they handle the twice quoted paths differently. I tested that this change does not adversely affect windows and linux.
